### PR TITLE
Use next_expectedarrivaltime if next_expecteddeparturetime missing

### DIFF
--- a/foli.py
+++ b/foli.py
@@ -56,8 +56,10 @@ def handle_journeys(raw):
         fields_not_found = []
         for rf in required_fields:
             if rf not in vehicle:
-                if rf == 'next_expecteddeparturetime' and 'next_expectedarrivaltime' in vehicle:
-                    vehicle['next_expecteddeparturetime'] = vehicle['next_expectedarrivaltime']
+                if rf == 'next_expecteddeparturetime' and 'next_aimeddeparturetime' in vehicle:
+                    vehicle['next_expecteddeparturetime'] = vehicle['next_aimeddeparturetime']
+                elif rf == 'next_expectedarrivaltime' and 'next_aimedarrivaltime' in vehicle::
+                    vehicle['next_expectedarrivaltime'] = vehicle['next_aimedarrivaltime']
                 else:
                     fields_not_found.append(rf)
 

--- a/foli.py
+++ b/foli.py
@@ -57,9 +57,15 @@ def handle_journeys(raw):
         for rf in required_fields:
             if rf not in vehicle:
                 if rf == 'next_expecteddeparturetime' and 'next_aimeddeparturetime' in vehicle:
-                    vehicle['next_expecteddeparturetime'] = vehicle['next_aimeddeparturetime']
+                    if 'next_expectedarrivaltime' in vehicle and vehicle['next_expectedarrivaltime'] > vehicle['next_aimeddeparturetime']:
+                        vehicle['next_expecteddeparturetime'] = vehicle['next_expectedarrivaltime']
+                    else:
+                        vehicle['next_expecteddeparturetime'] = vehicle['next_aimeddeparturetime']
                 elif rf == 'next_expectedarrivaltime' and 'next_aimedarrivaltime' in vehicle:
-                    vehicle['next_expectedarrivaltime'] = vehicle['next_aimedarrivaltime']
+                    if 'next_expecteddeparturetime' in vehicle and vehicle['next_expecteddeparturetime'] < vehicle['next_aimedarrivaltime']:
+                        vehicle['next_expectedarrivaltime'] = vehicle['next_expecteddeparturetime']
+                    else:
+                        vehicle['next_expectedarrivaltime'] = vehicle['next_aimedarrivaltime']
                 else:
                     fields_not_found.append(rf)
 

--- a/foli.py
+++ b/foli.py
@@ -56,7 +56,10 @@ def handle_journeys(raw):
         fields_not_found = []
         for rf in required_fields:
             if rf not in vehicle:
-                fields_not_found.append(rf)
+                if rf == 'next_expecteddeparturetime' and 'next_expectedarrivaltime' in vehicle:
+                    vehicle['next_expecteddeparturetime'] = vehicle['next_expectedarrivaltime']
+                else:
+                    fields_not_found.append(rf)
 
         if len(fields_not_found) > 0:
             logging.error("Fields missing from FOLI vehicle %s (%s)" % (i, ', '.join(fields_not_found)))

--- a/foli.py
+++ b/foli.py
@@ -58,7 +58,7 @@ def handle_journeys(raw):
             if rf not in vehicle:
                 if rf == 'next_expecteddeparturetime' and 'next_aimeddeparturetime' in vehicle:
                     vehicle['next_expecteddeparturetime'] = vehicle['next_aimeddeparturetime']
-                elif rf == 'next_expectedarrivaltime' and 'next_aimedarrivaltime' in vehicle::
+                elif rf == 'next_expectedarrivaltime' and 'next_aimedarrivaltime' in vehicle:
                     vehicle['next_expectedarrivaltime'] = vehicle['next_aimedarrivaltime']
                 else:
                     fields_not_found.append(rf)


### PR DESCRIPTION
Some change in turku's systems caused 'next_expecteddeparturetime' field to be missing for some vehicles. As a fallback, we can use 'next_expectedarrivaltime.